### PR TITLE
remove superfluous records from pipeline

### DIFF
--- a/lib/tsvparser.js
+++ b/lib/tsvparser.js
@@ -9,7 +9,9 @@ function factory(){
     cells.forEach( function( cell, i ){
       row[ columns[ i ] ] = ( cell || '' ).trim();
     });
-    this.push( row );
+    if( !!chunk ){
+      this.push( row );
+    }
     next();
   };
 


### PR DESCRIPTION
There is a superfluous record output at the stream when using `npm split` which wasn't present when using `npm byline`.
It's probably because the file contains a line containing only whitespace at the end of the TSV document.
