### PR TITLE
Reusable streams

### DIFF
--- a/lib/unzip.js
+++ b/lib/unzip.js
@@ -5,8 +5,11 @@ var unzip = require('unzip'),
     passthrough = require('readable-stream/passthrough');
 
 module.exports = function() {
-  var output = new passthrough(),
-    parser = unzip.Parse()
+
+  var output = new passthrough();
+  var parser = unzip.Parse();
+
+  parser
     .on( 'error', console.error.bind( console ) )
     .on( 'entry', function( entry ) {
       // skip readme files
@@ -20,4 +23,4 @@ module.exports = function() {
   parser.unpipe( output );
 
   return stream;
-}
+};

--- a/lib/unzip.js
+++ b/lib/unzip.js
@@ -2,10 +2,11 @@
 // stream unzip files
 var unzip = require('unzip'),
     bun = require('bun'),
-    output = new require('readable-stream/passthrough')();
+    passthrough = require('readable-stream/passthrough');
 
-module.exports = function(){
-  var parser = unzip.Parse()
+module.exports = function() {
+  var output = new passthrough(),
+    parser = unzip.Parse()
     .on( 'error', console.error.bind( console ) )
     .on( 'entry', function( entry ) {
       // skip readme files

--- a/test/reusable-streams.js
+++ b/test/reusable-streams.js
@@ -1,0 +1,59 @@
+
+// Test cases in reference to:
+// https://github.com/geopipes/geonames-stream/issues/9
+
+var geonames = require('../');
+
+module.exports.reusable = {};
+
+// @todo: please make the test below pass:
+
+// module.exports.reusable.unzip = function(test, common) {
+//   test('unzip', function(t) {
+
+//     var s1 = geonames.unzip();
+//     s1.end();
+
+//     var s2 = geonames.unzip();
+//     s2.end();
+
+//     t.end();
+//   });
+// };
+
+module.exports.reusable.parser = function(test, common) {
+  test('parser', function(t) {
+
+    var s1 = geonames.parser();
+    s1.end();
+
+    var s2 = geonames.parser();
+    s2.end();
+
+    t.end();
+  });
+};
+
+module.exports.reusable.modifiers = function(test, common) {
+  test('modifiers', function(t) {
+
+    var s1 = geonames.modifiers();
+    s1.end();
+
+    var s2 = geonames.modifiers();
+    s2.end();
+
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('reusable streams: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.reusable ){
+    module.exports.reusable[testCase](test, common);
+  }
+};

--- a/test/run.js
+++ b/test/run.js
@@ -4,9 +4,10 @@ var tape = require('tape');
 var common = {};
 
 var tests = [
-  require('./interface.js')
+  require('./interface.js'),
+  require('./reusable-streams.js')
 ];
 
 tests.map(function(t) {
-  t.all(tape, common)
+  t.all(tape, common);
 });


### PR DESCRIPTION
This PR fixes the issue outlined in https://github.com/geopipes/geonames-stream/issues/9, specifically that the `passthrough` stream should be instantiated once per `unzip()` and not as a singleton, which resulted in it trying to be re-used and erroring.

I've merged in https://github.com/geopipes/geonames-stream/pull/10 and spent some time trying to write some unit tests which will prevent this issue coming back. Due to time constraints I wasn't able to get the `unzip` test to pass, I'm really not sure what is going on but established that it is something to do with `unzip.Parse()` holding the process hostage and not allowing the test suite to exit.

For now, let's merge and release this to benefit from the work done by @royaltm, thanks!