### PR TITLE
Custom schemas support

### DIFF
--- a/lib/tsvparser.js
+++ b/lib/tsvparser.js
@@ -1,8 +1,28 @@
 
-var columns = require('../schema').columns,
+var schema = require('../schema'),
     through = require('through2');
 
-function factory(){
+var defaultSchema = schema.geoname;
+
+/**
+ * @param {sring|Array} customSchema Custom schema Array or name of the existing in shema.json
+ */
+function factory(customSchema){
+
+  customSchema = customSchema || defaultSchema;
+
+  var columns;
+
+  switch( customSchema.constructor ){
+    case String:
+      columns = schema[customSchema];
+      break;
+    case Array:
+      columns = customSchema;
+      break;
+    default:
+      throw new TypeError('customSchema must be a string or an array');
+  }
 
   var flush = function( chunk, _, next ){
     var row = {}, cells = chunk.toString('utf-8').split('\t');

--- a/schema.json
+++ b/schema.json
@@ -7,5 +7,8 @@
   "alternate_names": [
     "alternate_name_id", "geoname_id", "iso_language", "alternate_name",
     "is_preferred_name", "is_short_name", "is_colloquial", "is_historic"
+  ],
+  "hierarchy": [
+    "parent_id", "child_id", "type"
   ]
 }

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 {
-  "columns": [
+  "geoname": [
     "_id", "name", "asciiname", "alternatenames", "latitude", "longitude", "feature_class",
     "feature_code", "country_code", "cc2", "admin1_code", "admin2_code", "admin3_code",
     "admin4_code", "population", "elevation", "dem", "timezone", "modification_date"

--- a/schema.json
+++ b/schema.json
@@ -3,5 +3,9 @@
     "_id", "name", "asciiname", "alternatenames", "latitude", "longitude", "feature_class",
     "feature_code", "country_code", "cc2", "admin1_code", "admin2_code", "admin3_code",
     "admin4_code", "population", "elevation", "dem", "timezone", "modification_date"
+  ],
+  "alternate_names": [
+    "alternate_name_id", "geoname_id", "iso_language", "alternate_name",
+    "is_preferred_name", "is_short_name", "is_colloquial", "is_historic"
   ]
 }

--- a/schema.json
+++ b/schema.json
@@ -10,5 +10,8 @@
   ],
   "hierarchy": [
     "parent_id", "child_id", "type"
+  ],
+  "user_tags": [
+    "geoname_id", "tag"
   ]
 }


### PR DESCRIPTION
This PR adds the feature of custom scheme definition or select from preset. This will allow to parse any files from dump.

```javascript
var geonames = require('geonames-stream'),
    request = require('request');

request.get( 'http://download.geonames.org/export/dump/userTags.zip' )
  .pipe( geonames.unzip() )
  .pipe( split() )
  .pipe( geonames.parser( [
    'geonameId',
    'tag'
  ] ) )
  .pipe( geonames.stringify )
  .pipe( process.stdout );

// or

request.get( 'http://download.geonames.org/export/dump/userTags.zip' )
  .pipe( geonames.unzip() )
  .pipe( split() )
  .pipe( geonames.parser( 'user_tags' ) )
  .pipe( geonames.stringify )
  .pipe( process.stdout );
```