### PR TITLE
Refresh package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - 0.12
   - 4
-  - 5
   - 6
 install:
   - npm install
@@ -16,5 +14,3 @@ cache:
     - node_modules
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: 6

--- a/README.md
+++ b/README.md
@@ -133,6 +133,6 @@ $ npm test
 
 ### Continuous Integration
 
-Travis tests every release against node version `0.10`
+Travis tests every release against Node.js versions `4` and `6`.
 
 [![Build Status](https://travis-ci.org/geopipes/geonames-stream.png?branch=master)](https://travis-ci.org/geopipes/geonames-stream)

--- a/lib/unzip.js
+++ b/lib/unzip.js
@@ -1,6 +1,6 @@
 
 // stream unzip files
-var unzip = require('unzip'),
+var unzip = require('unzipper'),
     bun = require('bun'),
     passthrough = require('readable-stream/passthrough');
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bun": "0.0.10",
     "unzipper": "^0.7.2",
     "readable-stream": "^1.0.33",
-    "split": "^0.3.1",
+    "split": "^1.0.0",
     "through2": "^0.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "request": "^2.38.0",
-    "tape": "^2.13.4",
+    "tape": "^4.6.3",
     "tap-spec": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "unzipper": "^0.7.2",
     "readable-stream": "^1.0.33",
     "split": "^1.0.0",
-    "through2": "^0.5.1"
+    "through2": "^2.0.3"
   },
   "devDependencies": {
     "request": "^2.38.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "bun": "0.0.10",
-    "unzip": "https://github.com/glebdmitriew/node-unzip-2/tarball/master",
+    "unzipper": "^0.7.2",
     "readable-stream": "^1.0.33",
     "split": "^0.3.1",
     "through2": "^0.5.1"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   "devDependencies": {
     "request": "^2.38.0",
     "tape": "^4.6.3",
-    "tap-spec": "^0.2.0"
+    "tap-spec": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/geopipes/geonames-stream/issues"
   },
   "engines": {
-    "node": ">=0.10.26",
+    "node": ">=4.0.0",
     "npm": ">=1.4.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "bun": "0.0.10",
     "unzipper": "^0.7.2",
-    "readable-stream": "^1.0.33",
+    "readable-stream": "^2.2.2",
     "split": "^1.0.0",
     "through2": "^2.0.3"
   },


### PR DESCRIPTION
We haven't touched this package in a while. In addition to using the `unzipper` package which replaces the unmaintained `unzip` package, this PR updates all the dependencies, and requires Node 4 or higher.